### PR TITLE
Support syntax CCACHE_COMPILERCHECK=hash:<random_hash_string>

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -281,6 +281,9 @@ setting key. Boolean options are indicated with ``[boolean]''
     compiler's source has not changed, or if the compiler only has changes that
     don't affect code generation). You should only use the *none* setting if
     you know what you are doing.
+*string:value*::
+    Use *value* as the string to calculate hash from. This can be the compiler
+    revision number you retrieved earlier and set here via environment variable.
 _a command string_::
     Hash the standard output and standard error output of the specified
     command. The string will be split on whitespace to find out the command and

--- a/ccache.c
+++ b/ccache.c
@@ -1106,6 +1106,9 @@ hash_compiler(struct mdfour *hash, struct stat *st, const char *path,
 		hash_delimiter(hash, "cc_mtime");
 		hash_int(hash, st->st_size);
 		hash_int(hash, st->st_mtime);
+	} else if (str_startswith(conf->compiler_check, "string:")) {
+		hash_delimiter(hash, "cc_hash");
+		hash_string(hash, conf->compiler_check + strlen("string:"));
 	} else if (str_eq(conf->compiler_check, "content") || !allow_command) {
 		hash_delimiter(hash, "cc_content");
 		hash_file(hash, path);


### PR DESCRIPTION
This can be faster than running a command directly, because the command to run might just produce the same result for every ccache invocation. By reading it from config file or environment variable we can just run that command once and store the result in the string following `"hash:"` and reusing it.

For example when we want to use clang revision for clang built from SVN trunk, we can just call `clang --version` once and store the revision number like:

    export COMPILERCHECK=hash:218707

(Assuming 218707 is the current build revision.)