### PR TITLE
[RFC PATCH] Added hash abstractions

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -388,12 +388,12 @@ get_path_in_cache(const char *name, const char *suffix)
  * also updated. Takes over ownership of path.
  */
 static void
-remember_include_file(char *path, struct mdfour *cpp_hash)
+remember_include_file(char *path, struct hstate *cpp_hash)
 {
 #ifdef _WIN32
 	DWORD attributes;
 #endif
-	struct mdfour fhash;
+	struct hstate fhash;
 	struct stat st;
 	char *source = NULL;
 	size_t size;
@@ -459,7 +459,7 @@ remember_include_file(char *path, struct mdfour *cpp_hash)
 			goto failure;
 		}
 		hash_result_as_bytes(&fhash, pch_hash.hash);
-		pch_hash.size = fhash.totalN;
+		pch_hash.size = hash_get_len(&fhash);
 		hash_delimiter(cpp_hash, "pch_hash");
 		hash_buffer(cpp_hash, pch_hash.hash, sizeof(pch_hash.hash));
 	}
@@ -487,7 +487,7 @@ remember_include_file(char *path, struct mdfour *cpp_hash)
 
 		h = x_malloc(sizeof(*h));
 		hash_result_as_bytes(&fhash, h->hash);
-		h->size = fhash.totalN;
+		h->size = hash_get_len(&fhash);
 		hashtable_insert(included_files, path, h);
 	} else {
 		free(path);
@@ -568,7 +568,7 @@ make_relative_path(char *path)
  *   included_files.
  */
 static bool
-process_preprocessed_file(struct mdfour *hash, const char *path)
+process_preprocessed_file(struct hstate *hash, const char *path)
 {
 	char *data;
 	char *p, *q, *end;
@@ -951,7 +951,7 @@ to_cache(struct args *args)
  * Returns the hash as a heap-allocated hex string.
  */
 static struct file_hash *
-get_object_name_from_cpp(struct args *args, struct mdfour *hash)
+get_object_name_from_cpp(struct args *args, struct hstate *hash)
 {
 	char *input_base;
 	char *tmp;
@@ -1051,7 +1051,7 @@ get_object_name_from_cpp(struct args *args, struct mdfour *hash)
 
 	result = x_malloc(sizeof(*result));
 	hash_result_as_bytes(hash, result->hash);
-	result->size = hash->totalN;
+	result->size = hash_get_len(hash);
 	return result;
 }
 
@@ -1074,7 +1074,7 @@ update_cached_result_globals(struct file_hash *hash)
  * the CCACHE_COMPILERCHECK setting.
  */
 static void
-hash_compiler(struct mdfour *hash, struct stat *st, const char *path,
+hash_compiler(struct hstate *hash, struct stat *st, const char *path,
               bool allow_command)
 {
 	if (str_eq(conf->compiler_check, "none")) {
@@ -1122,7 +1122,7 @@ compiler_is_gcc(struct args *args)
  * modes.
  */
 static void
-calculate_common_hash(struct args *args, struct mdfour *hash)
+calculate_common_hash(struct args *args, struct hstate *hash)
 {
 	struct stat st;
 	char *p;
@@ -1198,7 +1198,7 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
  * otherwise NULL. Caller frees.
  */
 static struct file_hash *
-calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
+calculate_object_hash(struct args *args, struct hstate *hash, int direct_mode)
 {
 	int i;
 	char *manifest_name;
@@ -2570,9 +2570,9 @@ ccache(int argc, char *argv[])
 	bool put_object_in_manifest = false;
 	struct file_hash *object_hash;
 	struct file_hash *object_hash_from_manifest = NULL;
-	struct mdfour common_hash;
-	struct mdfour direct_hash;
-	struct mdfour cpp_hash;
+	struct hstate common_hash;
+	struct hstate direct_hash;
+	struct hstate cpp_hash;
 
 	/* Arguments (except -E) to send to the preprocessor. */
 	struct args *preprocessor_args;

--- a/hash.c
+++ b/hash.c
@@ -18,45 +18,64 @@
  */
 
 #include "ccache.h"
+#include "mdfour.h"
+#include "murmurhashneutral2.h"
 
 #define HASH_DELIMITER "\000cCaChE"
 
-void
-hash_start(struct mdfour *md)
+unsigned
+hash_simple(const void* input, size_t length, unsigned seed) {
+        return murmurhashneutral2(input, length, seed);
+}
+
+#if HNAME == mdfour
+size_t
+hash_get_len(struct hstate *hstate)
 {
+        struct mdfour *md = (struct mdfour *) hstate;
+	return (size_t) md->totalN;
+}
+
+void
+hash_start(struct hstate *hstate)
+{
+        struct mdfour *md = (struct mdfour *) hstate;
 	mdfour_begin(md);
 }
 
 void
-hash_buffer(struct mdfour *md, const void *s, size_t len)
+hash_buffer(struct hstate *hstate, const void *s, size_t len)
 {
+        struct mdfour *md = (struct mdfour *) hstate;
 	mdfour_update(md, (unsigned char *)s, len);
-}
-
-/* Return the hash result as a hex string. Caller frees. */
-char *
-hash_result(struct mdfour *md)
-{
-	unsigned char sum[16];
-
-	hash_result_as_bytes(md, sum);
-	return format_hash_as_string(sum, (unsigned) md->totalN);
 }
 
 /* return the hash result as 16 binary bytes */
 void
-hash_result_as_bytes(struct mdfour *md, unsigned char *out)
+hash_result_as_bytes(struct hstate *hstate, void *out)
 {
-	hash_buffer(md, NULL, 0);
-	mdfour_result(md, out);
+        struct mdfour *md = (struct mdfour *) hstate;
+        hash_buffer(hstate, NULL, 0);
+        mdfour_result(md, out);
+}
+#endif
+
+/* Return the hash result as a hex string. Caller frees. */
+char *
+hash_result(struct hstate *hstate)
+{
+	unsigned char sum[HSIZE];
+
+	hash_result_as_bytes(hstate, sum);
+	return format_hash_as_string(sum, hash_get_len(hstate));
 }
 
 bool
-hash_equal(struct mdfour *md1, struct mdfour *md2)
+hash_equal(struct hstate *hstate1, struct hstate *hstate2)
 {
-	unsigned char sum1[16], sum2[16];
-	hash_result_as_bytes(md1, sum1);
-	hash_result_as_bytes(md2, sum2);
+	unsigned char sum1[HSIZE], sum2[HSIZE];
+	hash_result_as_bytes(hstate1, sum1);
+	hash_result_as_bytes(hstate2, sum2);
 	return memcmp(sum1, sum2, sizeof(sum1)) == 0;
 }
 
@@ -71,28 +90,28 @@ hash_equal(struct mdfour *md1, struct mdfour *md2)
  *   there should never be a hash collision risk).
  */
 void
-hash_delimiter(struct mdfour *md, const char *type)
+hash_delimiter(struct hstate *hstate, const char *type)
 {
-	hash_buffer(md, HASH_DELIMITER, sizeof(HASH_DELIMITER));
-	hash_buffer(md, type, strlen(type) + 1); /* Include NUL. */
+	hash_buffer(hstate, HASH_DELIMITER, sizeof(HASH_DELIMITER));
+	hash_buffer(hstate, type, strlen(type) + 1); /* Include NUL. */
 }
 
 void
-hash_string(struct mdfour *md, const char *s)
+hash_string(struct hstate *hstate, const char *s)
 {
-	hash_string_length(md, s, strlen(s));
+	hash_string_length(hstate, s, strlen(s));
 }
 
 void
-hash_string_length(struct mdfour *md, const char *s, int length)
+hash_string_length(struct hstate *hstate, const char *s, int length)
 {
-        hash_buffer(md, s, length);
+        hash_buffer(hstate, s, length);
 }
 
 void
-hash_int(struct mdfour *md, int x)
+hash_int(struct hstate *hstate, int x)
 {
-	hash_buffer(md, (char *)&x, sizeof(x));
+	hash_buffer(hstate, (char *)&x, sizeof(x));
 }
 
 /*
@@ -100,7 +119,7 @@ hash_int(struct mdfour *md, int x)
  * false.
  */
 bool
-hash_fd(struct mdfour *md, int fd)
+hash_fd(struct hstate *hstate, int fd)
 {
 	char buf[16384];
 	ssize_t n;
@@ -110,7 +129,7 @@ hash_fd(struct mdfour *md, int fd)
 			break;
 		}
 		if (n > 0) {
-			hash_buffer(md, buf, n);
+			hash_buffer(hstate, buf, n);
 		}
 	}
 	return n == 0;
@@ -121,7 +140,7 @@ hash_fd(struct mdfour *md, int fd)
  * false.
  */
 bool
-hash_file(struct mdfour *md, const char *fname)
+hash_file(struct hstate *hstate, const char *fname)
 {
 	int fd;
 	bool ret;
@@ -131,7 +150,7 @@ hash_file(struct mdfour *md, const char *fname)
 		return false;
 	}
 
-	ret = hash_fd(md, fd);
+	ret = hash_fd(hstate, fd);
 	close(fd);
 	return ret;
 }

--- a/hashutil.c
+++ b/hashutil.c
@@ -18,19 +18,18 @@
 
 #include "ccache.h"
 #include "hashutil.h"
-#include "murmurhashneutral2.h"
 #include "macroskip.h"
 
 unsigned
 hash_from_string(void *str)
 {
-	return murmurhashneutral2(str, strlen((const char *)str), 0);
+	return hash_simple(str, strlen((const char *)str), 0);
 }
 
 unsigned
 hash_from_int(int i)
 {
-	return murmurhashneutral2(&i, sizeof(int), 0);
+	return hash_simple(&i, sizeof(int), 0);
 }
 
 int
@@ -104,7 +103,7 @@ check_for_temporal_macros(const char *str, size_t len)
  */
 int
 hash_source_code_string(
-	struct conf *conf, struct mdfour *hash, const char *str, size_t len,
+	struct conf *conf, struct hstate *hash, const char *str, size_t len,
 	const char *path)
 {
 	int result = HASH_SOURCE_CODE_OK;
@@ -155,7 +154,7 @@ hash_source_code_string(
  * results.
  */
 int
-hash_source_code_file(struct conf *conf, struct mdfour *hash, const char *path)
+hash_source_code_file(struct conf *conf, struct hstate *hash, const char *path)
 {
 	char *data;
 	size_t size;
@@ -179,7 +178,7 @@ hash_source_code_file(struct conf *conf, struct mdfour *hash, const char *path)
 }
 
 bool
-hash_command_output(struct mdfour *hash, const char *command,
+hash_command_output(struct hstate *hash, const char *command,
                     const char *compiler)
 {
 #ifdef _WIN32
@@ -296,7 +295,7 @@ hash_command_output(struct mdfour *hash, const char *command,
 }
 
 bool
-hash_multicommand_output(struct mdfour *hash, const char *commands,
+hash_multicommand_output(struct hstate *hash, const char *commands,
                          const char *compiler)
 {
 	char *command_string, *command, *p, *saveptr = NULL;

--- a/hashutil.h
+++ b/hashutil.h
@@ -1,8 +1,8 @@
 #ifndef HASHUTIL_H
 #define HASHUTIL_H
 
+#include "ccache.h"
 #include "conf.h"
-#include "mdfour.h"
 #include <inttypes.h>
 
 struct file_hash
@@ -23,13 +23,13 @@ int file_hashes_equal(struct file_hash *fh1, struct file_hash *fh2);
 
 int check_for_temporal_macros(const char *str, size_t len);
 int hash_source_code_string(
-	struct conf *conf, struct mdfour *hash, const char *str, size_t len,
+	struct conf *conf, struct hstate *hash, const char *str, size_t len,
 	const char *path);
 int hash_source_code_file(
-	struct conf *conf, struct mdfour *hash, const char *path);
-bool hash_command_output(struct mdfour *hash, const char *command,
+	struct conf *conf, struct hstate *hash, const char *path);
+bool hash_command_output(struct hstate *hash, const char *command,
                          const char *compiler);
-bool hash_multicommand_output(struct mdfour *hash, const char *command,
+bool hash_multicommand_output(struct hstate *hash, const char *command,
                               const char *compiler);
 
 #endif

--- a/manifest.c
+++ b/manifest.c
@@ -128,7 +128,7 @@ static unsigned int
 hash_from_file_info(void *key)
 {
 	ccache_static_assert(sizeof(struct file_info) == 40); /* No padding. */
-	return murmurhashneutral2(key, sizeof(struct file_info), 0);
+	return hash_simple(key, sizeof(struct file_info), 0);
 }
 
 static int
@@ -383,7 +383,7 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 	struct file_info *fi;
 	struct file_hash *actual;
 	struct file_stats *st;
-	struct mdfour hash;
+	struct hstate hash;
 	int result;
 	char *path;
 
@@ -437,7 +437,7 @@ verify_object(struct conf *conf, struct manifest *mf, struct object *obj,
 				return 0;
 			}
 			hash_result_as_bytes(&hash, actual->hash);
-			actual->size = hash.totalN;
+			actual->size = hash_get_len(&hash);
 			hashtable_insert(hashed_files, x_strdup(path), actual);
 		}
 		if (memcmp(fi->hash, actual->hash, mf->hash_size) != 0

--- a/mdfour.c
+++ b/mdfour.c
@@ -17,6 +17,7 @@
  */
 
 #include "ccache.h"
+#include "mdfour.h"
 
 /* NOTE: This code makes no attempt to be fast! */
 

--- a/test/test_hash.c
+++ b/test/test_hash.c
@@ -27,7 +27,7 @@ TEST_SUITE(hash)
 
 TEST(test_vectors_from_rfc_1320_should_be_correct)
 {
-	struct mdfour h;
+	struct hstate h;
 
 	hash_start(&h);
 	hash_string(&h, "");
@@ -48,7 +48,7 @@ TEST(test_vectors_from_rfc_1320_should_be_correct)
 
 TEST(hash_result_should_be_idempotent)
 {
-	struct mdfour h;
+	struct hstate h;
 
 	hash_start(&h);
 	hash_string(&h, "");

--- a/test/test_hashutil.c
+++ b/test/test_hashutil.c
@@ -29,7 +29,7 @@ TEST_SUITE(hashutil)
 
 TEST(hash_command_output_simple)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	CHECK(hash_command_output(&h1, "echo", "not used"));
@@ -39,7 +39,7 @@ TEST(hash_command_output_simple)
 
 TEST(hash_command_output_space_removal)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	CHECK(hash_command_output(&h1, "echo", "not used"));
@@ -49,7 +49,7 @@ TEST(hash_command_output_space_removal)
 
 TEST(hash_command_output_hash_inequality)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	CHECK(hash_command_output(&h1, "echo foo", "not used"));
@@ -59,7 +59,7 @@ TEST(hash_command_output_hash_inequality)
 
 TEST(hash_command_output_compiler_substitution)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	CHECK(hash_command_output(&h1, "echo foo", "not used"));
@@ -69,7 +69,7 @@ TEST(hash_command_output_compiler_substitution)
 
 TEST(hash_command_output_stdout_versus_stderr)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	create_file("stderr.sh", "#!/bin/sh\necho foo >&2\n");
@@ -81,7 +81,7 @@ TEST(hash_command_output_stdout_versus_stderr)
 
 TEST(hash_multicommand_output)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	create_file("foo.sh", "#!/bin/sh\necho foo\necho bar\n");
@@ -93,7 +93,7 @@ TEST(hash_multicommand_output)
 
 TEST(hash_multicommand_output_error_handling)
 {
-	struct mdfour h1, h2;
+	struct hstate h1, h2;
 	hash_start(&h1);
 	hash_start(&h2);
 	CHECK(!hash_multicommand_output(&h2, "false; true", "not used"));

--- a/unify.c
+++ b/unify.c
@@ -106,7 +106,7 @@ build_table(void)
 
 /* buffer up characters before hashing them */
 static void
-pushchar(struct mdfour *hash, unsigned char c)
+pushchar(struct hstate *hash, unsigned char c)
 {
 	static unsigned char buf[64];
 	static size_t len;
@@ -129,7 +129,7 @@ pushchar(struct mdfour *hash, unsigned char c)
 
 /* hash some C/C++ code after unifying */
 static void
-unify(struct mdfour *hash, unsigned char *p, size_t size)
+unify(struct hstate *hash, unsigned char *p, size_t size)
 {
 	size_t ofs;
 	unsigned char q;
@@ -248,7 +248,7 @@ unify(struct mdfour *hash, unsigned char *p, size_t size)
    number information from the hash
 */
 int
-unify_hash(struct mdfour *hash, const char *fname)
+unify_hash(struct hstate *hash, const char *fname)
 {
 	char *data;
 	size_t size;

--- a/util.c
+++ b/util.c
@@ -525,7 +525,7 @@ format_hash_as_string(const unsigned char *hash, int size)
 	int i;
 
 	ret = x_malloc(53);
-	for (i = 0; i < 16; i++) {
+	for (i = 0; i < HSIZE; i++) {
 		sprintf(&ret[i*2], "%02x", (unsigned) hash[i]);
 	}
 	if (size >= 0) {


### PR DESCRIPTION
Added hash abstraction for simplify at compile time change of hash algorithm

created struct hstate; for allow in future change hash algorithm by config.
All functions just allocate enough memory for handle any hash's state what ccache supported;

Signed-off-by: Timofey Titovets <nefelim4ag@gmail.com>