### PR TITLE
Pass -stdlib= only to preprocessor

### DIFF
--- a/compopt.c
+++ b/compopt.c
@@ -78,6 +78,7 @@ static const struct compopt compopts[] = {
 	{"-nostdinc++",     AFFECTS_CPP},
 	{"-remap",          AFFECTS_CPP},
 	{"-save-temps",     TOO_HARD},
+	{"-stdlib=",        AFFECTS_CPP | TAKES_CONCAT_ARG},
 	{"-trigraphs",      AFFECTS_CPP},
 	{"-u",              TAKES_ARG},
 };


### PR DESCRIPTION
Clang warns about an unused -stdlib=libc++ argument if the argument is
passed to the second clang invocation. The -stdlib= argument is only
necessary on preprocessing (to set the system include paths) and on
linking (which is not cached anyway)

Signed-off-by: Matthias Kretz <kretz@kde.org>