### PR TITLE
Add initial travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,34 @@
+language: c
+
+addons:
+    apt:
+        packages:
+            - zlib1g-dev
+
+os:
+    - linux
+    - osx
+
+compiler:
+    - clang
+    - gcc
+
+matrix:
+    include:
+        - os: linux
+          compiler: clang
+          env: CFLAGS="-fsanitize=address -g" ASAN_OPTIONS="detect_leaks=0"
+    exclude:
+        - os: osx
+          compiler: gcc
+
+script:
+    - ./autogen.sh
+    - ./configure
+    - make
+    - if [ "$CC" == "gcc" ]; then
+          ./test.sh;
+      fi
+
+#notifications:
+#    email: ccache@lists.samba.org


### PR DESCRIPTION
Hi there!

I added an initial configuration for travis-ci. I disabled tests for non-gcc compilers as they fail at the moment.
I think mingw32 should be added, too. Maybe appveyor.com and coveralls.io could be added. ;-)

OpenSSL uses mingw32:
https://github.com/openssl/openssl/blob/master/.travis.yml

You need to create a free travis account and enable ccache repository on your profile page: https://travis-ci.org/profile/
