### PR TITLE
Always run the unit tests during check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
     - ./autogen.sh
     - ./configure
     - make
+    - make quicktest
     - if [ "$CC" = "gcc" ]; then
           ./test.sh;
       fi


### PR DESCRIPTION
Should probably fix the "test.sh" script for clang with ELF, so that "make test" can be run instead ?
Currently there are some problems, like the name of the preprocessed file being recorded instead.