### PR TITLE
Debuginfo and -fdebug-prefix-map

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -376,7 +376,7 @@ WRAPPERS>>.
     working directory in the debug info set incorrectly. This option is off by
     default as the incorrect setting of this debug info rarely causes problems.
     If you strike problems with GDB not using the correct directory then enable
-    this option.
+    this option. The option *only* applies when generating debug info (-g).
 
 *ignore_headers_in_manifest* (*CCACHE_IGNOREHEADERS*)::
 

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -242,6 +242,10 @@ setting key. Boolean options are indicated with ``[boolean]''
     directory. If set to the empty string (which is the default), no rewriting
     is done. See also the discussion under
     <<_compiling_in_different_directories,COMPILING IN DIFFERENT DIRECTORIES>>.
+    If using GCC*, you might want to look into the *-fdebug-prefix-map* option
+    for relocating debug info to a common prefix (mapping prefix with old=new).
+
+    * or newer versions of Clang, see: http://reviews.llvm.org/rL250094
 
 *cache_dir* (*CCACHE_DIR*)::
 

--- a/NEWS.txt
+++ b/NEWS.txt
@@ -28,6 +28,9 @@ New features and improvements
 - If hard-linking is enabled and but fails (e.g. due to cross-device linking),
   ccache now falls back to copying instead of running the compiler.
 
+- Add support for relocating debuginfo cwd using `-f-debug-prefix-map`.
+  This allows getting cache hits with base_dir, even using hash_dir.
+
 
 Bug fixes
 ~~~~~~~~~

--- a/ccache.c
+++ b/ccache.c
@@ -183,6 +183,9 @@ static char **ignore_headers;
 /* Size of headers to ignore list */
 static size_t ignore_headers_len;
 
+/* is gcc being asked to output debug info? */
+static bool generating_debuginfo;
+
 /* is gcc being asked to output dependencies? */
 static bool generating_dependencies;
 
@@ -1489,7 +1492,7 @@ calculate_common_hash(struct args *args, struct mdfour *hash)
 	free(p);
 
 	/* Possibly hash the current working directory. */
-	if (conf->hash_dir) {
+	if (generating_debuginfo && conf->hash_dir) {
 		char *cwd = gnu_getcwd();
 		if (debug_prefix_map) {
 			char *map = debug_prefix_map;
@@ -2215,6 +2218,7 @@ cc_process_args(struct args *args, struct args **preprocessor_args,
 		/* Debugging is handled specially, so that we know if we can strip line
 		 * number info. */
 		if (str_startswith(argv[i], "-g")) {
+			generating_debuginfo = true;
 			args_add(stripped_args, argv[i]);
 			if (conf->unify && !str_eq(argv[i], "-g0")) {
 				cc_log("%s used; disabling unify mode", argv[i]);
@@ -3059,6 +3063,7 @@ cc_reset(void)
 	if (included_files) {
 		hashtable_destroy(included_files, 1); included_files = NULL;
 	}
+	generating_debuginfo = false;
 	generating_dependencies = false;
 	generating_coverage = false;
 	profile_arcs = false;

--- a/test.sh
+++ b/test.sh
@@ -294,16 +294,14 @@ base_tests() {
     checkstat 'files in cache' 4
 
     testname="CCACHE_HASHDIR"
-    CCACHE_HASHDIR=1 $CCACHE_COMPILE -c test1.c -O -O
+    CCACHE_HASHDIR=1 $CCACHE_COMPILE -c test1.c -g -O -O
     checkstat 'cache hit (preprocessed)' 5
     checkstat 'cache miss' 5
-    compare_object reference_test1.o test1.o
 
-    CCACHE_HASHDIR=1 $CCACHE_COMPILE -c test1.c -O -O
+    CCACHE_HASHDIR=1 $CCACHE_COMPILE -c test1.c -g -O -O
     checkstat 'cache hit (preprocessed)' 6
     checkstat 'cache miss' 5
     checkstat 'files in cache' 5
-    compare_object reference_test1.o test1.o
 
     testname="comments"
     echo '/* a silly comment */' > test1-comment.c

--- a/test.sh
+++ b/test.sh
@@ -2442,11 +2442,11 @@ clang_pch_suite() {
 
     testname="pth, preprocessor mode"
     $CCACHE -Cz >/dev/null
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS=time_macros $CCACHE $COMPILER $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$default_sloppiness pch_defines time_macros" $CCACHE $COMPILER $SYSROOT -c -include pch.h -fpch-preprocess pch.c
     checkstat 'cache hit (direct)' 0
     checkstat 'cache hit (preprocessed)' 0
     checkstat 'cache miss' 1
-    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS=time_macros $CCACHE $COMPILER $SYSROOT -c -include pch.h -fpch-preprocess pch.c
+    CCACHE_NODIRECT=1 CCACHE_SLOPPINESS="$default_sloppiness pch_defines time_macros" $CCACHE $COMPILER $SYSROOT -c -include pch.h -fpch-preprocess pch.c
     checkstat 'cache hit (direct)' 0
     checkstat 'cache hit (preprocessed)' 1
     checkstat 'cache miss' 1


### PR DESCRIPTION
This is relevant in the light of global activation of ccache and global setting of CCACHE_HASHDIR:
https://bugzilla.redhat.com/show_bug.cgi?id=759592

By relocating the gcc debuginfo (similar to relocating source with CCACHE_BASEDIR),
it should be possible to still get cache hits even when generating debugging information...