### PR TITLE
Handle "Stale NFS File Handle" cases better.

### DIFF
--- a/util.c
+++ b/util.c
@@ -881,7 +881,7 @@ traverse(const char *dir, void (*fn)(const char *, struct stat *))
 
 		fname = format("%s/%s", dir, de->d_name);
 		if (lstat(fname, &st)) {
-			if (errno != ENOENT) {
+			if ((errno != ENOENT) && (errno != ESTALE)) {
 				fatal("lstat %s failed: %s", fname, strerror(errno));
 			}
 			free(fname);


### PR DESCRIPTION
This is in response to #68 

I came across an earlier commit, 3049c10, that was resolving a similar issue.  I believe adding ESTALE as a condition to ignore may be appropriate as well. 

edit, I meant 8d91b7c