### PR TITLE
Fix clang plugin hashing.

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -1700,6 +1700,7 @@ calculate_object_hash(struct args *args, struct mdfour *hash, int direct_mode)
 		    && x_stat(args->argv[i+3], &st) == 0) {
 			hash_delimiter(hash, "plugin");
 			hash_compiler(hash, &st, args->argv[i+3], false);
+			i += 3;
 			continue;
 		}
 


### PR DESCRIPTION
This matters when compiling in different directories and clang plugin
is located in them. make_relative_path is redundant in that case.

https://lists.samba.org/archive/ccache/2016q1/001425.html