### PR TITLE
Fix warnings from uncrustify

### DIFF
--- a/test/main.c
+++ b/test/main.c
@@ -24,9 +24,11 @@
 #include "getopt_long.h"
 #endif
 
+/* *INDENT-OFF* disable uncrustify */
 #define SUITE(name) unsigned suite_ ## name(unsigned);
 #include "test/suites.h"
 #undef SUITE
+/* *INDENT-ON* enable uncrustify */
 
 const char USAGE_TEXT[] =
   "Usage:\n"

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1225,7 +1225,7 @@ mod_full_brace_if                        = add   # ignore/add/remove/force
 
 # Make all if/elseif/else statements in a chain be braced or not. Overrides mod_full_brace_if.
 # If any must be braced, they are all braced.  If all can be unbraced, then the braces are removed.
-mod_full_brace_if_chain                  = add    # false/true
+mod_full_brace_if_chain                  = false    # false/true
 
 # Don't remove braces around statements that span N newlines
 mod_full_brace_nl                        = 0        # number


### PR DESCRIPTION
Seems like 6fa07483c5d11a35d49de26b724b7528073ab95e left the "uncrustify" target in a bad state:

`uncrustify.cfg:1228 Expected 'True' or 'False' for mod_full_brace_if_chain, got add`

Also fix this old warning, by disabling uncrustify for SUITE(name):

`test/main.c:27 Detected a macro that ends with a semicolon. Expect failures if used.`