### PR TITLE
Increase cache hit by removing path sensitivity of identical header f…

### DIFF
--- a/ccache.c
+++ b/ccache.c
@@ -863,7 +863,6 @@ process_preprocessed_file(struct mdfour *hash, const char *path)
 				has_absolute_include_headers = is_absolute_path(path);
 			}
 			path = make_relative_path(path);
-			hash_string(hash, path);
 			remember_include_file(path, hash, system);
 			p = r;
 		} else {


### PR DESCRIPTION
…iles

When using preprocess mode for hashing, the header file path gets included
into the hash. When two identical headers have different path for whatever
reason, the hash will not yield the same result cause a cache miss when
infact nothing changed except for the header include path.

Please see this thread: http://www.mail-archive.com/ccache@lists.samba.org/msg01329.html
